### PR TITLE
Fix pagination issue / Change output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# planning
-Scripts to help with planning.
+# Planning
+
+Tool to scan a GitHub issue for a specific label, and "size estimates", and compute an overall
+point total. To help with planning.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 
 Tool to scan a GitHub issue for a specific label, and "size estimates", and compute an overall
 point total. To help with planning.
+
+## Development
+
+Example usage:
+
+```bash
+go install && \
+    planning --org="pulumi" --label="20Q1-Svc"
+```


### PR DESCRIPTION
Two commits:

- The first changes the output of the tool, to include the milestone, assignee, and URL to the issue. (This makes it easier to later sort by option/owner and also fix unlabeled issues.)
- The second fixes a bug. We were only making a single call to `Issues.ListByOrg` which means we would only ever see ~100 (or whatever the default is). The change looks at the `response.NextPage` value and issues subsequent API requests as needed.

Happy to make any changes you'd like.

As for future changes, my thinking is that it would be helpful to "buffer" results in memory. (e.g. build a `[]sizedIssue`), which we would then display the same output after sorting by milestone, point-size, and assignee. Do you think those would be a good set of changes to make?
